### PR TITLE
Alwats empty the change dicts after updating contents

### DIFF
--- a/AFMasterViewController.m
+++ b/AFMasterViewController.m
@@ -213,10 +213,10 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
                 }
             } completion:nil];
         }
-        
-        [_sectionChanges removeAllObjects];
-        [_objectChanges removeAllObjects];
     }
+
+    [_sectionChanges removeAllObjects];
+    [_objectChanges removeAllObjects];
 }
 
 - (BOOL)shouldReloadCollectionViewToPreventKnownIssue {


### PR DESCRIPTION
It seems like the change dicts can be left with updates from a previous set of changes if there are changes in both objects and sections. The patch moves the emptying out of the if case so it's always performed at the end.
