### PR TITLE
Simplify implementation using blocks

### DIFF
--- a/AFMasterViewController.m
+++ b/AFMasterViewController.m
@@ -17,27 +17,7 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     NSMutableArray *_sectionChanges;
 }
 
-- (void)awakeFromNib
-{
-    [super awakeFromNib];
-}
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-	// Do any additional setup after loading the view, typically from a nib.
-    
-    _objectChanges = [NSMutableArray array];
-    _sectionChanges = [NSMutableArray array];
-}
-
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
-#pragma mark - UICollectionVIew
+#pragma mark - UICollectionView
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
 {
@@ -104,153 +84,79 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     return _fetchedResultsController;
 }    
 
+- (void)controllerWillChangeContent:(NSFetchedResultsController *)controller
+{
+    _objectChanges = [NSMutableArray array];
+    _sectionChanges = [NSMutableArray array];
+}
+
 - (void)controller:(NSFetchedResultsController *)controller didChangeSection:(id <NSFetchedResultsSectionInfo>)sectionInfo
            atIndex:(NSUInteger)sectionIndex forChangeType:(NSFetchedResultsChangeType)type
 {
-    
-    NSMutableDictionary *change = [NSMutableDictionary new];
-    
+    __weak UICollectionView *collectionView = self.collectionView;
     switch(type) {
         case NSFetchedResultsChangeInsert:
-            change[@(type)] = @(sectionIndex);
+            [_sectionChanges addObject:^{
+                [collectionView insertSections:[NSIndexSet indexSetWithIndex:sectionIndex]];
+            }];
             break;
         case NSFetchedResultsChangeDelete:
-            change[@(type)] = @(sectionIndex);
+            [_sectionChanges addObject:^{
+                [collectionView deleteSections:[NSIndexSet indexSetWithIndex:sectionIndex]];
+            }];
             break;
     }
-    
-    [_sectionChanges addObject:change];
 }
 
 - (void)controller:(NSFetchedResultsController *)controller didChangeObject:(id)anObject
        atIndexPath:(NSIndexPath *)indexPath forChangeType:(NSFetchedResultsChangeType)type
       newIndexPath:(NSIndexPath *)newIndexPath
 {
-    
-    NSMutableDictionary *change = [NSMutableDictionary new];
-    switch(type)
-    {
+    __weak UICollectionView *collectionView = self.collectionView;
+    switch(type) {
         case NSFetchedResultsChangeInsert:
-            change[@(type)] = newIndexPath;
+            [_objectChanges addObject:^{
+                [collectionView insertItemsAtIndexPaths:@[newIndexPath]];
+            }];
             break;
+            
         case NSFetchedResultsChangeDelete:
-            change[@(type)] = indexPath;
+            [_objectChanges addObject:^{
+                [collectionView deleteItemsAtIndexPaths:@[indexPath]];
+            }];
             break;
+            
         case NSFetchedResultsChangeUpdate:
-            change[@(type)] = indexPath;
+            [_objectChanges addObject:^{
+                [collectionView reloadItemsAtIndexPaths:@[indexPath]];
+            }];
             break;
+            
         case NSFetchedResultsChangeMove:
-            change[@(type)] = @[indexPath, newIndexPath];
+            [_objectChanges addObject:^{
+                [collectionView moveItemAtIndexPath:indexPath toIndexPath:newIndexPath];
+            }];
             break;
     }
-    [_objectChanges addObject:change];
 }
 
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
 {
-    if ([_sectionChanges count] > 0)
-    {
-        [self.collectionView performBatchUpdates:^{
-            
-            for (NSDictionary *change in _sectionChanges)
-            {
-                [change enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, id obj, BOOL *stop) {
-                    
-                    NSFetchedResultsChangeType type = [key unsignedIntegerValue];
-                    switch (type)
-                    {
-                        case NSFetchedResultsChangeInsert:
-                            [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];
-                            break;
-                        case NSFetchedResultsChangeDelete:
-                            [self.collectionView deleteSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];
-                            break;
-                        case NSFetchedResultsChangeUpdate:
-                            [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];
-                            break;
-                    }
-                }];
-            }
-        } completion:nil];
-    }
+    NSArray *sectionChanges = _sectionChanges;
+    NSArray *objectChanges = _objectChanges;
     
-    if ([_objectChanges count] > 0 && [_sectionChanges count] == 0)
-    {
-        
-        if ([self shouldReloadCollectionViewToPreventKnownIssue] || self.collectionView.window == nil) {
-            // This is to prevent a bug in UICollectionView from occurring.
-            // The bug presents itself when inserting the first object or deleting the last object in a collection view.
-            // http://stackoverflow.com/questions/12611292/uicollectionview-assertion-failure
-            // This code should be removed once the bug has been fixed, it is tracked in OpenRadar
-            // http://openradar.appspot.com/12954582
-            [self.collectionView reloadData];
-            
-        } else {
-
-            [self.collectionView performBatchUpdates:^{
-                
-                for (NSDictionary *change in _objectChanges)
-                {
-                    [change enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, id obj, BOOL *stop) {
-                        
-                        NSFetchedResultsChangeType type = [key unsignedIntegerValue];
-                        switch (type)
-                        {
-                            case NSFetchedResultsChangeInsert:
-                                [self.collectionView insertItemsAtIndexPaths:@[obj]];
-                                break;
-                            case NSFetchedResultsChangeDelete:
-                                [self.collectionView deleteItemsAtIndexPaths:@[obj]];
-                                break;
-                            case NSFetchedResultsChangeUpdate:
-                                [self.collectionView reloadItemsAtIndexPaths:@[obj]];
-                                break;
-                            case NSFetchedResultsChangeMove:
-                                [self.collectionView moveItemAtIndexPath:obj[0] toIndexPath:obj[1]];
-                                break;
-                        }
-                    }];
-                }
-            } completion:nil];
+    [self.collectionView performBatchUpdates:^{
+        for (void (^block)(void) in sectionChanges) {
+            block();
         }
-    }
-
-    [_sectionChanges removeAllObjects];
-    [_objectChanges removeAllObjects];
-}
-
-- (BOOL)shouldReloadCollectionViewToPreventKnownIssue {
-    __block BOOL shouldReload = NO;
-    for (NSDictionary *change in self.objectChanges) {
-        [change enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            NSFetchedResultsChangeType type = [key unsignedIntegerValue];
-            NSIndexPath *indexPath = obj;
-            switch (type) {
-                case NSFetchedResultsChangeInsert:
-                    if ([self.collectionView numberOfItemsInSection:indexPath.section] == 0) {
-                        shouldReload = YES;
-                    } else {
-                        shouldReload = NO;
-                    }
-                    break;
-                case NSFetchedResultsChangeDelete:
-                    if ([self.collectionView numberOfItemsInSection:indexPath.section] == 1) {
-                        shouldReload = YES;
-                    } else {
-                        shouldReload = NO;
-                    }
-                    break;
-                case NSFetchedResultsChangeUpdate:
-                    shouldReload = NO;
-                    break;
-                case NSFetchedResultsChangeMove:
-                    shouldReload = NO;
-                    break;
-            }
-        }];
-    }
+        for (void (^block)(void) in objectChanges) {
+            block();
+        }
+    } completion:nil];
     
-    return shouldReload;
+    _sectionChanges = nil;
+    _objectChanges = nil;
+
 }
 
 @end


### PR DESCRIPTION
No need for ad-hoc change dictionaries and such. Fixes #13

I deleted the code purporting to fix Apple bug 12954582 as it didn't seem particularly relevant to the aim of the repo as stated in the README and muddied the example. (It was also a convenient excuse to not figure out the contortions needed to port the bug workaround over to this blocks-based implementation.)

Moreover, using `NSBlockOperation` did not seem like a good fit. Using it simply as an array of blocks offers no obvious benefits over, well, a simple array of blocks. Plus it's not guaranteed to execute on the main thread.
