### PR TITLE
Updated Ash Furrow’s original.

### DIFF
--- a/AFMasterViewController.m
+++ b/AFMasterViewController.m
@@ -148,7 +148,7 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
 {
     NSMutableArray *moves = _objectChanges[@(NSFetchedResultsChangeMove)];
-    if (moves.count) {
+    if (moves.count > 0) {
         NSMutableArray *updatedMoves = [[NSMutableArray alloc] initWithCapacity:moves.count];
         
         NSMutableIndexSet *insertSections = _sectionChanges[@(NSFetchedResultsChangeInsert)];
@@ -180,7 +180,7 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
             }
         }
         
-        if (updatedMoves.count) {
+        if (updatedMoves.count > 0) {
             _objectChanges[@(NSFetchedResultsChangeMove)] = updatedMoves;
         } else {
             [_objectChanges removeObjectForKey:@(NSFetchedResultsChangeMove)];
@@ -188,7 +188,7 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     }
     
     NSMutableArray *deletes = _objectChanges[@(NSFetchedResultsChangeDelete)];
-    if (deletes.count) {
+    if (deletes.count > 0) {
         NSMutableIndexSet *deletedSections = _sectionChanges[@(NSFetchedResultsChangeDelete)];
         [deletes filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSIndexPath *evaluatedObject, NSDictionary *bindings) {
             return ![deletedSections containsIndex:evaluatedObject.section];
@@ -196,7 +196,7 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     }
     
     NSMutableArray *inserts = _objectChanges[@(NSFetchedResultsChangeInsert)];
-    if (inserts.count) {
+    if (inserts.count > 0) {
         NSMutableIndexSet *insertedSections = _sectionChanges[@(NSFetchedResultsChangeInsert)];
         [inserts filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSIndexPath *evaluatedObject, NSDictionary *bindings) {
             return ![insertedSections containsIndex:evaluatedObject.section];
@@ -207,27 +207,27 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     
     [collectionView performBatchUpdates:^{
         NSIndexSet *deletedSections = _sectionChanges[@(NSFetchedResultsChangeDelete)];
-        if (deletedSections.count) {
+        if (deletedSections.count > 0) {
             [collectionView deleteSections:deletedSections];
         }
         
         NSIndexSet *insertedSections = _sectionChanges[@(NSFetchedResultsChangeInsert)];
-        if (insertedSections.count) {
+        if (insertedSections.count > 0) {
             [collectionView insertSections:insertedSections];
         }
         
         NSArray *deletedItems = _objectChanges[@(NSFetchedResultsChangeDelete)];
-        if (deletedItems.count) {
+        if (deletedItems.count > 0) {
             [collectionView deleteItemsAtIndexPaths:deletedItems];
         }
         
         NSArray *insertedItems = _objectChanges[@(NSFetchedResultsChangeInsert)];
-        if (insertedItems.count) {
+        if (insertedItems.count > 0) {
             [collectionView insertItemsAtIndexPaths:insertedItems];
         }
         
         NSArray *reloadItems = _objectChanges[@(NSFetchedResultsChangeUpdate)];
-        if (reloadItems.count) {
+        if (reloadItems.count > 0) {
             [collectionView reloadItemsAtIndexPaths:reloadItems];
         }
         

--- a/AFMasterViewController.m
+++ b/AFMasterViewController.m
@@ -26,7 +26,6 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
 {
     [super viewDidLoad];
 	// Do any additional setup after loading the view, typically from a nib.
-    
 }
 
 - (void)didReceiveMemoryWarning
@@ -171,10 +170,10 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
             } else if ([insertSections containsIndex:toIP.section]) {
                 NSMutableArray *changeSet = _objectChanges[@(NSFetchedResultsChangeDelete)];
                 if (changeSet == nil) {
-                    changeSet = [[NSMutableArray alloc] initWithObjects:toIP, nil];
+                    changeSet = [[NSMutableArray alloc] initWithObjects:fromIP, nil];
                     _objectChanges[@(NSFetchedResultsChangeDelete)] = changeSet;
                 } else {
-                    [changeSet addObject:toIP];
+                    [changeSet addObject:fromIP];
                 }
             } else {
                 [updatedMoves addObject:move];

--- a/AFMasterViewController.m
+++ b/AFMasterViewController.m
@@ -13,8 +13,8 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
 
 @implementation AFMasterViewController
 {
-    NSMutableArray *_objectChanges;
-    NSMutableArray *_sectionChanges;
+    NSMutableDictionary *_objectChanges;
+    NSMutableDictionary *_sectionChanges;
 }
 
 - (void)awakeFromNib
@@ -27,8 +27,6 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
     [super viewDidLoad];
 	// Do any additional setup after loading the view, typically from a nib.
     
-    _objectChanges = [NSMutableArray array];
-    _sectionChanges = [NSMutableArray array];
 }
 
 - (void)didReceiveMemoryWarning
@@ -102,155 +100,146 @@ static NSString *CellIdentifier = @"AFCollectionViewCell";
 	}
     
     return _fetchedResultsController;
-}    
+}
+
+- (void)controllerWillChangeContent:(NSFetchedResultsController *)controller {
+    _objectChanges = [NSMutableDictionary dictionary];
+    _sectionChanges = [NSMutableDictionary dictionary];
+}
 
 - (void)controller:(NSFetchedResultsController *)controller didChangeSection:(id <NSFetchedResultsSectionInfo>)sectionInfo
            atIndex:(NSUInteger)sectionIndex forChangeType:(NSFetchedResultsChangeType)type
 {
-    
-    NSMutableDictionary *change = [NSMutableDictionary new];
-    
-    switch(type) {
-        case NSFetchedResultsChangeInsert:
-            change[@(type)] = @(sectionIndex);
-            break;
-        case NSFetchedResultsChangeDelete:
-            change[@(type)] = @(sectionIndex);
-            break;
+    if (type == NSFetchedResultsChangeInsert || type == NSFetchedResultsChangeDelete) {
+        NSMutableIndexSet *changeSet = _sectionChanges[@(type)];
+        if (changeSet != nil) {
+            [changeSet addIndex:sectionIndex];
+        } else {
+            _sectionChanges[@(type)] = [[NSMutableIndexSet alloc] initWithIndex:sectionIndex];
+        }
     }
-    
-    [_sectionChanges addObject:change];
 }
 
 - (void)controller:(NSFetchedResultsController *)controller didChangeObject:(id)anObject
        atIndexPath:(NSIndexPath *)indexPath forChangeType:(NSFetchedResultsChangeType)type
       newIndexPath:(NSIndexPath *)newIndexPath
 {
+    NSMutableArray *changeSet = _objectChanges[@(type)];
+    if (changeSet == nil) {
+        changeSet = [[NSMutableArray alloc] init];
+        _objectChanges[@(type)] = changeSet;
+    }
     
-    NSMutableDictionary *change = [NSMutableDictionary new];
-    switch(type)
-    {
+    switch(type) {
         case NSFetchedResultsChangeInsert:
-            change[@(type)] = newIndexPath;
+            [changeSet addObject:newIndexPath];
             break;
         case NSFetchedResultsChangeDelete:
-            change[@(type)] = indexPath;
+            [changeSet addObject:indexPath];
             break;
         case NSFetchedResultsChangeUpdate:
-            change[@(type)] = indexPath;
+            [changeSet addObject:indexPath];
             break;
         case NSFetchedResultsChangeMove:
-            change[@(type)] = @[indexPath, newIndexPath];
+            [changeSet addObject:@[indexPath, newIndexPath]];
             break;
     }
-    [_objectChanges addObject:change];
 }
 
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
 {
-    if ([_sectionChanges count] > 0)
-    {
-        [self.collectionView performBatchUpdates:^{
-            
-            for (NSDictionary *change in _sectionChanges)
-            {
-                [change enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, id obj, BOOL *stop) {
-                    
-                    NSFetchedResultsChangeType type = [key unsignedIntegerValue];
-                    switch (type)
-                    {
-                        case NSFetchedResultsChangeInsert:
-                            [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];
-                            break;
-                        case NSFetchedResultsChangeDelete:
-                            [self.collectionView deleteSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];
-                            break;
-                        case NSFetchedResultsChangeUpdate:
-                            [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:[obj unsignedIntegerValue]]];
-                            break;
-                    }
-                }];
-            }
-        } completion:nil];
-    }
-    
-    if ([_objectChanges count] > 0 && [_sectionChanges count] == 0)
-    {
+    NSMutableArray *moves = _objectChanges[@(NSFetchedResultsChangeMove)];
+    if (moves.count) {
+        NSMutableArray *updatedMoves = [[NSMutableArray alloc] initWithCapacity:moves.count];
         
-        if ([self shouldReloadCollectionViewToPreventKnownIssue] || self.collectionView.window == nil) {
-            // This is to prevent a bug in UICollectionView from occurring.
-            // The bug presents itself when inserting the first object or deleting the last object in a collection view.
-            // http://stackoverflow.com/questions/12611292/uicollectionview-assertion-failure
-            // This code should be removed once the bug has been fixed, it is tracked in OpenRadar
-            // http://openradar.appspot.com/12954582
-            [self.collectionView reloadData];
+        NSMutableIndexSet *insertSections = _sectionChanges[@(NSFetchedResultsChangeInsert)];
+        NSMutableIndexSet *deleteSections = _sectionChanges[@(NSFetchedResultsChangeDelete)];
+        for (NSArray *move in moves) {
+            NSIndexPath *fromIP = move[0];
+            NSIndexPath *toIP = move[1];
             
-        } else {
-
-            [self.collectionView performBatchUpdates:^{
-                
-                for (NSDictionary *change in _objectChanges)
-                {
-                    [change enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, id obj, BOOL *stop) {
-                        
-                        NSFetchedResultsChangeType type = [key unsignedIntegerValue];
-                        switch (type)
-                        {
-                            case NSFetchedResultsChangeInsert:
-                                [self.collectionView insertItemsAtIndexPaths:@[obj]];
-                                break;
-                            case NSFetchedResultsChangeDelete:
-                                [self.collectionView deleteItemsAtIndexPaths:@[obj]];
-                                break;
-                            case NSFetchedResultsChangeUpdate:
-                                [self.collectionView reloadItemsAtIndexPaths:@[obj]];
-                                break;
-                            case NSFetchedResultsChangeMove:
-                                [self.collectionView moveItemAtIndexPath:obj[0] toIndexPath:obj[1]];
-                                break;
-                        }
-                    }];
+            if ([deleteSections containsIndex:fromIP.section]) {
+                if (![insertSections containsIndex:toIP.section]) {
+                    NSMutableArray *changeSet = _objectChanges[@(NSFetchedResultsChangeInsert)];
+                    if (changeSet == nil) {
+                        changeSet = [[NSMutableArray alloc] initWithObjects:toIP, nil];
+                        _objectChanges[@(NSFetchedResultsChangeInsert)] = changeSet;
+                    } else {
+                        [changeSet addObject:toIP];
+                    }
                 }
-            } completion:nil];
+            } else if ([insertSections containsIndex:toIP.section]) {
+                NSMutableArray *changeSet = _objectChanges[@(NSFetchedResultsChangeDelete)];
+                if (changeSet == nil) {
+                    changeSet = [[NSMutableArray alloc] initWithObjects:toIP, nil];
+                    _objectChanges[@(NSFetchedResultsChangeDelete)] = changeSet;
+                } else {
+                    [changeSet addObject:toIP];
+                }
+            } else {
+                [updatedMoves addObject:move];
+            }
+        }
+        
+        if (updatedMoves.count) {
+            _objectChanges[@(NSFetchedResultsChangeMove)] = updatedMoves;
+        } else {
+            [_objectChanges removeObjectForKey:@(NSFetchedResultsChangeMove)];
         }
     }
-
-    [_sectionChanges removeAllObjects];
-    [_objectChanges removeAllObjects];
-}
-
-- (BOOL)shouldReloadCollectionViewToPreventKnownIssue {
-    __block BOOL shouldReload = NO;
-    for (NSDictionary *change in self.objectChanges) {
-        [change enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            NSFetchedResultsChangeType type = [key unsignedIntegerValue];
-            NSIndexPath *indexPath = obj;
-            switch (type) {
-                case NSFetchedResultsChangeInsert:
-                    if ([self.collectionView numberOfItemsInSection:indexPath.section] == 0) {
-                        shouldReload = YES;
-                    } else {
-                        shouldReload = NO;
-                    }
-                    break;
-                case NSFetchedResultsChangeDelete:
-                    if ([self.collectionView numberOfItemsInSection:indexPath.section] == 1) {
-                        shouldReload = YES;
-                    } else {
-                        shouldReload = NO;
-                    }
-                    break;
-                case NSFetchedResultsChangeUpdate:
-                    shouldReload = NO;
-                    break;
-                case NSFetchedResultsChangeMove:
-                    shouldReload = NO;
-                    break;
-            }
-        }];
+    
+    NSMutableArray *deletes = _objectChanges[@(NSFetchedResultsChangeDelete)];
+    if (deletes.count) {
+        NSMutableIndexSet *deletedSections = _sectionChanges[@(NSFetchedResultsChangeDelete)];
+        [deletes filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSIndexPath *evaluatedObject, NSDictionary *bindings) {
+            return ![deletedSections containsIndex:evaluatedObject.section];
+        }]];
     }
     
-    return shouldReload;
+    NSMutableArray *inserts = _objectChanges[@(NSFetchedResultsChangeInsert)];
+    if (inserts.count) {
+        NSMutableIndexSet *insertedSections = _sectionChanges[@(NSFetchedResultsChangeInsert)];
+        [inserts filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSIndexPath *evaluatedObject, NSDictionary *bindings) {
+            return ![insertedSections containsIndex:evaluatedObject.section];
+        }]];
+    }
+    
+    UICollectionView *collectionView = self.collectionView;
+    
+    [collectionView performBatchUpdates:^{
+        NSIndexSet *deletedSections = _sectionChanges[@(NSFetchedResultsChangeDelete)];
+        if (deletedSections.count) {
+            [collectionView deleteSections:deletedSections];
+        }
+        
+        NSIndexSet *insertedSections = _sectionChanges[@(NSFetchedResultsChangeInsert)];
+        if (insertedSections.count) {
+            [collectionView insertSections:insertedSections];
+        }
+        
+        NSArray *deletedItems = _objectChanges[@(NSFetchedResultsChangeDelete)];
+        if (deletedItems.count) {
+            [collectionView deleteItemsAtIndexPaths:deletedItems];
+        }
+        
+        NSArray *insertedItems = _objectChanges[@(NSFetchedResultsChangeInsert)];
+        if (insertedItems.count) {
+            [collectionView insertItemsAtIndexPaths:insertedItems];
+        }
+        
+        NSArray *reloadItems = _objectChanges[@(NSFetchedResultsChangeUpdate)];
+        if (reloadItems.count) {
+            [collectionView reloadItemsAtIndexPaths:reloadItems];
+        }
+        
+        NSArray *moveItems = _objectChanges[@(NSFetchedResultsChangeMove)];
+        for (NSArray *paths in moveItems) {
+            [collectionView moveItemAtIndexPath:paths[0] toIndexPath:paths[1]];
+        }
+    } completion:nil];
+    
+    _objectChanges = nil;
+    _sectionChanges = nil;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-Seriously, _don't_ use this repo anymore. Check out the [Status](#status) section.
-
 # UICollectionView+NSFetchedResultsController
 
-This is an example of how to use the new `UICollectionView` with `NSFetchedResultsController`. The trick is to queue the updates made through the `NSFetchedResultsControllerDelegate` until the controller *finishes* its updates. `UICollectionView` doesn't have the same `beginUpdates` and `endUpdates` that `UITableView` has to let it work easily with `NSFetchedResultsController`, so you have to queue them or you get internal consistency runtime exceptions.
+This is an example of how to use the new `UICollectionView` with `NSFetchedResultsController`. Unlike `UITableView`, which has `beginUpdates` and `endUpdates` methods, `UICollectionView` requires updates to be stored, and then submitted as a block to `performBatchUpdate:completion:`.
+
+`NSFetchedResultsController` is designed for use with `UITableView`, and as such is tuned for some of it's quirks. Table views allow updates to items within sections that are also being updated. `UICollectionView` runs into exceptions if you add items into sections that are being added, delete items from sections that are being deleted, etc. This means that when using `NSFetchedResultsController` and `UICollectionView`, you need to filter the updates so you do not perform changes within sections that are also changing.
 
 # Status
 
-This repository is *deprecated*. Please use [JSQDataSourcesKit](https://github.com/jessesquires/JSQDataSourcesKit) instead. 
+Supported as of iOS 8. When using Swift, you may want to consider using [JSQDataSourcesKit](https://github.com/jessesquires/JSQDataSourcesKit) or translating this to Swift.
 
 # Setup
 
 Clone the repo and look in the `UICollectionViewController` subclass. The logic inside the `.m` file shows how to queue updates.
 
-Section updates are stored in `_sectionChanges` while udates to objects within sections are stored in `_objectChanges`. When `controllerDidChangeContent:` is called, these updates are dequeued. 
+Section updates are stored in `_sectionChanges` while updates to objects within sections are stored in `_objectChanges`. When `controllerDidChangeContent:` is called, these updates are dequeued, coalesced, and then submitted as a block to the `UICollectionView`. 
 
 # Credit
 
-Most of the logic for this is taken from [this gist](https://gist.github.com/4440c1cba83318e276bb).
+Some of the logic for this is taken from [this gist](https://gist.github.com/4440c1cba83318e276bb). Additional thanks to [SixtyFrames](https://github.com/SixtyFrames) for the significant update adding change-filtering.


### PR DESCRIPTION
The central issue with the original implementation is that the changes of both sections and items were not coalesced for UICollectionView.

This update coalesces the changes. Where items are inserted into sections that are already being inserted, or deleted from sections already being deleted, it discards the updates.

It also alters the move requests, when moving to or from inserted or deleted sections, to be item insertion and deletions.